### PR TITLE
Add aggressive caching query-plugin

### DIFF
--- a/.github/workflows/dodeploy.yml
+++ b/.github/workflows/dodeploy.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Sending to DigitalOcean
       uses: LibreTexts/do-space-sync-action@master
       with:
-        args: --acl public-read
+        args: --acl public-read --cache-control "public,max-age=604800"
       env:
         SOURCE_DIR: './public'
         DEST_DIR: 'github/ckeditor-query-plugin'


### PR DESCRIPTION
Files on production will now be cached for up to a week in browser caches. (Can be overridden using CTRL+F5).

Addresses ballooning bandwidth overage costs.