### PR TITLE
Actually build plugin before Deployment

### DIFF
--- a/.github/workflows/dodeploy.yml
+++ b/.github/workflows/dodeploy.yml
@@ -1,8 +1,8 @@
 name: Sync to DigitalOcean Spaces
 
-on: 
+on:
   push:
-    branches: 
+    branches:
       - main
 
 jobs:
@@ -10,13 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-#     - name: Bump version number
-#       run: |
-#         VERSION=$(ls release/ | sort | tail -n1 | sed 's/\.md$//')
-#         DATE=$(TZ='America/Los_Angeles' date -I)
-#         VERSION_STR="Release: $VERSION - Date: $DATE"
-#         sed -i "s/Development Version/$VERSION_STR/" src/scripts/activateThebelab.js
-#         sed -i "s/0\.0\.0/$VERSION/" package.json
     - name: Building repo using Webpack
       run: |
         yarn install

--- a/.github/workflows/dodeploy.yml
+++ b/.github/workflows/dodeploy.yml
@@ -1,8 +1,8 @@
 name: Sync to DigitalOcean Spaces
 
-on:
+on: 
   push:
-    branches:
+    branches: 
       - main
 
 jobs:
@@ -10,12 +10,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
+#     - name: Bump version number
+#       run: |
+#         VERSION=$(ls release/ | sort | tail -n1 | sed 's/\.md$//')
+#         DATE=$(TZ='America/Los_Angeles' date -I)
+#         VERSION_STR="Release: $VERSION - Date: $DATE"
+#         sed -i "s/Development Version/$VERSION_STR/" src/scripts/activateThebelab.js
+#         sed -i "s/0\.0\.0/$VERSION/" package.json
+    - name: Building repo using Webpack
+      run: |
+        yarn install
+        yarn build
     - name: Sending to DigitalOcean
       uses: LibreTexts/do-space-sync-action@master
       with:
-        args: --acl public-read --cache-control "public,max-age=604800"
+        args: --acl public-read
       env:
-        SOURCE_DIR: './public'
+        SOURCE_DIR: './build'
         DEST_DIR: 'github/ckeditor-query-plugin'
         SPACE_NAME: ${{ secrets.Spaces_Name }}
         SPACE_REGION: ${{ secrets.Spaces_Region}}


### PR DESCRIPTION
Previous version did not actually build the files, so no files were being uploaded to the CDN. Changes borrowed from https://github.com/LibreTexts/ckeditor-binder-plugin/blob/staging/.github/workflows/main.yml

Plugin is currently being served from staging, this needs to change on my end once the initial deploy succeeds.