### PR TITLE
Updated link to Adapt's icon

### DIFF
--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -4,7 +4,7 @@
   background-size: 16px !important;
 }
 .cke_button_icon.cke_button__openlibretextsadaptdialog_icon {
-  background-image: url(https://adapt.libretexts.org/assets/img/favicon.png) !important;
+  background-image: url(https://d2xt85ly3365wl.cloudfront.net/4eb3ead8-6be4-4cfe-be83-e06cd40dd54b/assets/img/favicon.png) !important;
   background-position: 0 undefinedpx !important;
   background-size: 16px !important;
 }


### PR DESCRIPTION
Favicon url has been changed as Adapt is now deployed behind AWS Cloudfront.