### PR TITLE
Fix adapt icon

### DIFF
--- a/src/scripts/plugin.js
+++ b/src/scripts/plugin.js
@@ -123,7 +123,7 @@ const registerPlugin = () => {
         label: 'Insert Adapt',
         command: 'openLibretextsAdaptDialog',
         toolbar: 'insert',
-        icon: 'https://adapt.libretexts.org/favicon.ico',
+        icon: 'https://d2xt85ly3365wl.cloudfront.net/a4d94597-a806-4707-9756-b469103292a2/assets/img/favicon.png',
       });
     },
   });

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -4,7 +4,7 @@
   background-size: 16px !important;
 }
 .cke_button_icon.cke_button__openlibretextsadaptdialog_icon {
-  background-image: url(https://d2xt85ly3365wl.cloudfront.net/4eb3ead8-6be4-4cfe-be83-e06cd40dd54b/assets/img/favicon.png) !important;
+  background-image: url(https://d2xt85ly3365wl.cloudfront.net/a4d94597-a806-4707-9756-b469103292a2/assets/img/favicon.png) !important;
   background-position: 0 undefinedpx !important;
   background-size: 16px !important;
 }


### PR DESCRIPTION
The icon for the adapt button had a dead link. This should point it to a now-active one. We should determine a more permanent solution for these icons so this doesn't happen again.